### PR TITLE
Fix typo in class scope name

### DIFF
--- a/language/ahk.tmLanguage.yaml
+++ b/language/ahk.tmLanguage.yaml
@@ -42,8 +42,8 @@ repository:
           '5':
             name: support.class.ahk
         match: (?i:\b(class)\b\s*(\w+))\s*((extends)\s+(\w+))?
-        name: labelline.ahk
-        example: 'label:'
+        name: classline.ahk
+        example: 'class A extends B:'
       - captures:
           '1':
             name: entity.name.function.label.ahk

--- a/src/test/suite/grammar/samples/ahk-explorer.ahk.snap
+++ b/src/test/suite/grammar/samples/ahk-explorer.ahk.snap
@@ -6318,10 +6318,10 @@
 #^ source.ahk comment.line.semicolon.ahk punctuation.definition.comment.ahk
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ahk comment.line.semicolon.ahk
 >Class LV_Colors {
-#^^^^^ source.ahk labelline.ahk keyword.class.ahk
-#     ^ source.ahk labelline.ahk
-#      ^^^^^^^^^ source.ahk labelline.ahk support.class.ahk
-#               ^ source.ahk labelline.ahk
+#^^^^^ source.ahk classline.ahk keyword.class.ahk
+#     ^ source.ahk classline.ahk
+#      ^^^^^^^^^ source.ahk classline.ahk support.class.ahk
+#               ^ source.ahk classline.ahk
 #                ^ source.ahk punctuation.bracket.ahk
 >; +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 #^ source.ahk comment.line.semicolon.ahk punctuation.definition.comment.ahk


### PR DESCRIPTION
Changes proposed in this pull request:

- fit typo

Notifying @mark-wiemer
