### PR TITLE
Fix indent for one command code with continuation section

### DIFF
--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -603,18 +603,21 @@ export const internalFormat = (
                 (oneCommandCode || deferredOneCommandCode) &&
                 !nextLineIsOneCommandCode(purifiedLine)
             ) {
-                oneCommandCode = false;
                 if (deferredOneCommandCode) {
                     // if (a = 4
                     //     and b = 5) {
                     //     MsgBox <-- disable deferredOneCommandCode indent
                     // }
                     deferredOneCommandCode = false;
-                } else {
+                } else if (purifiedLine.match(/^{/)) {
                     // if (var)
                     // { <-- revert oneCommandCode indent for open brace
                     //     MsgBox
                     // }
+                    // if (var)
+                    //     obj := { key1: val1 <-- but not for object continuation
+                    //         , key2: val2 }                            section
+                    oneCommandCode = false;
                     depth -= openBraceNum;
                 }
                 // FLOW OF CONTROL revert added by mistake

--- a/src/test/suite/format/format.test.ts
+++ b/src/test/suite/format/format.test.ts
@@ -62,6 +62,7 @@ const formatTests: FormatTest[] = [
     { filenameRoot: '255-style-k-and-r' },
     { filenameRoot: '255-style-mix' },
     { filenameRoot: '255-style-one-true-brace' },
+    { filenameRoot: '316-if-object-continuation-section' },
     { filenameRoot: 'ahk-explorer' },
     { filenameRoot: 'align-assignment' },
     { filenameRoot: 'demo' },

--- a/src/test/suite/format/samples/255-close-brace.in.ahk
+++ b/src/test/suite/format/samples/255-close-brace.in.ahk
@@ -6,11 +6,17 @@ if
 if
 return
 }
-
 foo() {
 for
 for
 if
 return
+}
+foo() {
+if
+obj := {
+, {
+,
+, } }
 }
 }

--- a/src/test/suite/format/samples/255-close-brace.out.ahk
+++ b/src/test/suite/format/samples/255-close-brace.out.ahk
@@ -6,11 +6,17 @@
                 if
                     return
     }
-
     foo() {
         for
             for
                 if
                     return
+    }
+    foo() {
+        if
+            obj := {
+                , {
+                    ,
+                    , } }
     }
 }

--- a/src/test/suite/format/samples/316-if-object-continuation-section.in.ahk
+++ b/src/test/suite/format/samples/316-if-object-continuation-section.in.ahk
@@ -1,0 +1,11 @@
+; [Issue #316](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues/316)
+{
+if (expression)
+obj := { 0:""
+, a: 1
+, b: 2 }
+else
+obj := { 0:""
+, a: 2
+, b: 1 }
+}

--- a/src/test/suite/format/samples/316-if-object-continuation-section.out.ahk
+++ b/src/test/suite/format/samples/316-if-object-continuation-section.out.ahk
@@ -1,0 +1,11 @@
+; [Issue #316](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues/316)
+{
+    if (expression)
+        obj := { 0:""
+            , a: 1
+            , b: 2 }
+    else
+        obj := { 0:""
+            , a: 2
+            , b: 1 }
+}


### PR DESCRIPTION
Closes #316.

Changes proposed in this pull request:

- more strict regexp for open brace `{`

Notifying @mark-wiemer
