### PR TITLE
Grammar: #If directive highlight

### DIFF
--- a/language/ahk.tmLanguage.yaml
+++ b/language/ahk.tmLanguage.yaml
@@ -80,6 +80,15 @@ repository:
     patterns:
       - captures:
           '1':
+            patterns:
+              - include: '$self'
+          '2':
+            name: comment.line.semicolon.if.ahk
+        match: '#\b(?i:if)\b(.*?)(\s+;.*)?$'
+        name: keyword.control.if.ahk
+        example: '#if [expression]'
+      - captures:
+          '1':
             name: string.parameter.import.ahk
           '2':
             name: comment.line.semicolon.import.ahk
@@ -92,7 +101,7 @@ repository:
           '2':
             name: comment.line.semicolon.directive.ahk
         match: >-
-          #\b(?i:allowsamelinecomments|clipboardtimeout|commentflag|errorstdout|escapechar|hotkeyinterval|hotkeymodifiertimeout|hotstring|if|iftimeout|ifwinactive|ifwinexist|ifwinnotactive|ifwinnotexist|inputlevel|installkeybdhook|installmousehook|keyhistory|ltrim|maxhotkeysperinterval|maxmem|maxthreads|maxthreadsbuffer|maxthreadsperhotkey|menumaskkey|noenv|notrayicon|persistent|requires|singleinstance|usehook|warn|winactivateforce)\b(.*?)(\s+;.*)?$
+          #\b(?i:allowsamelinecomments|clipboardtimeout|commentflag|errorstdout|escapechar|hotkeyinterval|hotkeymodifiertimeout|hotstring|iftimeout|ifwinactive|ifwinexist|ifwinnotactive|ifwinnotexist|inputlevel|installkeybdhook|installmousehook|keyhistory|ltrim|maxhotkeysperinterval|maxmem|maxthreads|maxthreadsbuffer|maxthreadsperhotkey|menumaskkey|noenv|notrayicon|persistent|requires|singleinstance|usehook|warn|winactivateforce)\b(.*?)(\s+;.*)?$
         name: keyword.control.directives.ahk
         example: '#persistent'
       - match: >-

--- a/src/test/suite/grammar/samples/69-if-directive.ahk
+++ b/src/test/suite/grammar/samples/69-if-directive.ahk
@@ -1,0 +1,2 @@
+; [Issue #69](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues/69)
+#If WinActive("ahk_class Notepad") or WinActive(MyWindowTitle) ;Comment

--- a/src/test/suite/grammar/samples/69-if-directive.ahk.snap
+++ b/src/test/suite/grammar/samples/69-if-directive.ahk.snap
@@ -1,0 +1,21 @@
+>; [Issue #69](https://github.com/mark-wiemer/vscode-autohotkey-plus-plus/issues/69)
+#^ source.ahk comment.line.semicolon.ahk punctuation.definition.comment.ahk
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ahk comment.line.semicolon.ahk
+>#If WinActive("ahk_class Notepad") or WinActive(MyWindowTitle) ;Comment
+#^^^ source.ahk keyword.control.if.ahk
+#   ^ source.ahk keyword.control.if.ahk
+#    ^^^^^^^^^ source.ahk keyword.control.if.ahk support.function.ahk
+#             ^ source.ahk keyword.control.if.ahk punctuation.bracket.ahk
+#              ^ source.ahk keyword.control.if.ahk string.quoted.double.ahk punctuation.definition.string.begin.ahk
+#               ^^^^^^^^^^^^^^^^^ source.ahk keyword.control.if.ahk string.quoted.double.ahk
+#                                ^ source.ahk keyword.control.if.ahk string.quoted.double.ahk punctuation.definition.string.end.ahk
+#                                 ^ source.ahk keyword.control.if.ahk punctuation.bracket.ahk
+#                                  ^ source.ahk keyword.control.if.ahk
+#                                   ^^ source.ahk keyword.control.if.ahk keyword.other.ahk
+#                                     ^ source.ahk keyword.control.if.ahk
+#                                      ^^^^^^^^^ source.ahk keyword.control.if.ahk support.function.ahk
+#                                               ^ source.ahk keyword.control.if.ahk punctuation.bracket.ahk
+#                                                ^^^^^^^^^^^^^ source.ahk keyword.control.if.ahk variable.def.ahk
+#                                                             ^ source.ahk keyword.control.if.ahk punctuation.bracket.ahk
+#                                                              ^^^^^^^^^ source.ahk keyword.control.if.ahk comment.line.semicolon.if.ahk
+>

--- a/src/test/suite/grammar/samples/ahk-explorer.ahk.snap
+++ b/src/test/suite/grammar/samples/ahk-explorer.ahk.snap
@@ -13,7 +13,7 @@
 #      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ahk keyword.control.directives.ahk comment.line.semicolon.directive.ahk
 >#SingleInstance, force
 #^^^^^^^^^^^^^^^ source.ahk keyword.control.directives.ahk
-#               ^^^^^^^^ source.ahk keyword.control.directives.ahk string.parameter.directives.ahk
+#               ^^^^^^^ source.ahk keyword.control.directives.ahk string.parameter.directives.ahk
 >SendMode Input ; Recommended for new scripts due to its superior speed and reliability.
 #^^^^^^^^ source.ahk support.function.ahk
 #        ^ source.ahk
@@ -38,7 +38,7 @@
 #                ^ source.ahk constant.numeric.ahk
 >#KeyHistory 0
 #^^^^^^^^^^^ source.ahk keyword.control.directives.ahk
-#           ^^^ source.ahk keyword.control.directives.ahk string.parameter.directives.ahk
+#           ^^ source.ahk keyword.control.directives.ahk string.parameter.directives.ahk
 >ListLines Off
 #^^^^^^^^^ source.ahk support.function.ahk
 #         ^ source.ahk
@@ -59,10 +59,10 @@
 >
 >#MaxThreads, 20
 #^^^^^^^^^^^ source.ahk keyword.control.directives.ahk
-#           ^^^^^ source.ahk keyword.control.directives.ahk string.parameter.directives.ahk
+#           ^^^^ source.ahk keyword.control.directives.ahk string.parameter.directives.ahk
 >#MaxThreadsPerHotkey, 4
 #^^^^^^^^^^^^^^^^^^^^ source.ahk keyword.control.directives.ahk
-#                    ^^^^ source.ahk keyword.control.directives.ahk string.parameter.directives.ahk
+#                    ^^^ source.ahk keyword.control.directives.ahk string.parameter.directives.ahk
 >SetTitleMatchMode, 2
 #^^^^^^^^^^^^^^^^^ source.ahk support.function.ahk
 #                 ^ source.ahk punctuation.ahk
@@ -24348,8 +24348,12 @@
 #^ source.ahk comment.line.semicolon.ahk punctuation.definition.comment.ahk
 # ^^^^^^^ source.ahk comment.line.semicolon.ahk
 >#if winactive(thisUniqueWintitle)
-#^^^ source.ahk keyword.control.directives.ahk
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ahk keyword.control.directives.ahk string.parameter.directives.ahk
+#^^^ source.ahk keyword.control.if.ahk
+#   ^ source.ahk keyword.control.if.ahk
+#    ^^^^^^^^^ source.ahk keyword.control.if.ahk support.function.ahk
+#             ^ source.ahk keyword.control.if.ahk punctuation.bracket.ahk
+#              ^^^^^^^^^^^^^^^^^^ source.ahk keyword.control.if.ahk variable.def.ahk
+#                                ^ source.ahk keyword.control.if.ahk punctuation.bracket.ahk
 >^e::
 #^^ source.ahk hotkeyline.ahk entity.name.function.label.ahk
 #  ^^ source.ahk hotkeyline.ahk punctuation.definition.equals.colon
@@ -27822,8 +27826,14 @@
 #^^^^^^ source.ahk keyword.control.ahk
 >
 >#if winactive("renamingWinTitle ahk_class AutoHotkeyGUI")
-#^^^ source.ahk keyword.control.directives.ahk
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ahk keyword.control.directives.ahk string.parameter.directives.ahk
+#^^^ source.ahk keyword.control.if.ahk
+#   ^ source.ahk keyword.control.if.ahk
+#    ^^^^^^^^^ source.ahk keyword.control.if.ahk support.function.ahk
+#             ^ source.ahk keyword.control.if.ahk punctuation.bracket.ahk
+#              ^ source.ahk keyword.control.if.ahk string.quoted.double.ahk punctuation.definition.string.begin.ahk
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ahk keyword.control.if.ahk string.quoted.double.ahk
+#                                                       ^ source.ahk keyword.control.if.ahk string.quoted.double.ahk punctuation.definition.string.end.ahk
+#                                                        ^ source.ahk keyword.control.if.ahk punctuation.bracket.ahk
 >
 >$esc::
 #^^^^ source.ahk hotkeyline.ahk entity.name.function.label.ahk
@@ -27910,8 +27920,14 @@
 #^^^^^^ source.ahk keyword.control.ahk
 >
 >#if winactive("create_folder ahk_class AutoHotkeyGUI")
-#^^^ source.ahk keyword.control.directives.ahk
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ahk keyword.control.directives.ahk string.parameter.directives.ahk
+#^^^ source.ahk keyword.control.if.ahk
+#   ^ source.ahk keyword.control.if.ahk
+#    ^^^^^^^^^ source.ahk keyword.control.if.ahk support.function.ahk
+#             ^ source.ahk keyword.control.if.ahk punctuation.bracket.ahk
+#              ^ source.ahk keyword.control.if.ahk string.quoted.double.ahk punctuation.definition.string.begin.ahk
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ahk keyword.control.if.ahk string.quoted.double.ahk
+#                                                    ^ source.ahk keyword.control.if.ahk string.quoted.double.ahk punctuation.definition.string.end.ahk
+#                                                     ^ source.ahk keyword.control.if.ahk punctuation.bracket.ahk
 >
 >$enter::
 #^^^^^^ source.ahk hotkeyline.ahk entity.name.function.label.ahk


### PR DESCRIPTION
Closes #69. Plus closes №70 in AHK+ [https://github.com/vscode-autohotkey/autohotkey-plus/issues/70](https://github.com/vscode-autohotkey/autohotkey-plus/issues/70)

![Result](https://user-images.githubusercontent.com/964801/215264919-907cba07-6546-4e2e-a5ac-7242248ec138.png)

Changes proposed in this pull request:

- separate regex for `#If` directive

Notifying @mark-wiemer
