### PR TITLE
Fix: label regexp

### DIFF
--- a/src/providers/formattingProvider.ts
+++ b/src/providers/formattingProvider.ts
@@ -284,20 +284,20 @@ export const internalFormat = (
         /^(((and|or|not)\b)|[\^!~?:&<>=.,|]|\+(?!\+)|-(?!-)|\/(?!\*)|\*(?!\/))/;
     /**
      * Label name may consist of any characters other than `space`, `tab`,
-     * `comma` and the escape character (`).
+     * `comma` and the escape character (`). Not ended by double colon `::`.
      *
      * Generally, aside from whitespace and comments,
      * no other code can be written on the same line as a label.
      *
      * Example: `Label:`
      */
-    const label = /^[^\s\t,`]+:$/;
+    const label = /^[^\s\t,`]+(?<!:):$/;
     /**
      * Hotkey and hotstring without code after it.
      *
      * Example: `F1 & F2 Up::` (hotkey), `::btw::` (hotstring)
      */
-    const hotkey = /^.*::$/;
+    const hotkey = /^.+::$/;
     /**
      * `#Directive`, that will create context-sensitive hotkeys and hotstrings.
      * Example of `#Directives`:

--- a/src/test/suite/format/format.test.ts
+++ b/src/test/suite/format/format.test.ts
@@ -92,6 +92,7 @@ const formatTests: FormatTest[] = [
         options: { insertSpaces: false },
     },
     { filenameRoot: 'legacy-text-sharp-directive' },
+    { filenameRoot: 'label-colon' },
     { filenameRoot: 'label-combination' },
     { filenameRoot: 'label-fall-through' },
     { filenameRoot: 'label-specific-name' },

--- a/src/test/suite/format/samples/label-colon.in.ahk
+++ b/src/test/suite/format/samples/label-colon.in.ahk
@@ -1,0 +1,3 @@
+::
+code ;no indent
+Return

--- a/src/test/suite/format/samples/label-colon.out.ahk
+++ b/src/test/suite/format/samples/label-colon.out.ahk
@@ -1,0 +1,3 @@
+::
+code ;no indent
+Return


### PR DESCRIPTION
Changes proposed in this pull request:

- label can't end with `::`
- name must have some characters, change quantifier `*` to `+`

Notifying @mark-wiemer
